### PR TITLE
fix: Blocking behavior when services aren't up

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ export const runner = async (
         );
       } catch (error: unknown) {
         if (error instanceof Error) {
-          console.log(error.message);
+          console.log(`${service}:${port} failed with: ${error.message}\n`);
         }
 
         spinner.text = `⚠️ Failed connecting to ${service}:${port}`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,12 +44,22 @@ export const runner = async (
   await Promise.all(
     Object.entries(data).map(async ([key, uri]) => {
       const { service, port, path } = parseUri(uri);
-      const res = await portForward(kc, service, namespace, port);
-      spinner.text = `${service}:${port} → 127.0.0.1:${res.port}`;
-      environment.set(
-        key,
-        path ? `http://localhost:${res.port}${path}` : `localhost:${res.port}`,
-      );
+      try {
+        const res = await portForward(kc, service, namespace, port);
+        spinner.text = `${service}:${port} → 127.0.0.1:${res.port}`;
+        environment.set(
+          key,
+          path
+            ? `http://localhost:${res.port}${path}`
+            : `localhost:${res.port}`,
+        );
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.log(error.message);
+        }
+
+        spinner.text = `⚠️ Failed connecting to ${service}:${port}`;
+      }
     }),
   );
 


### PR DESCRIPTION
Adds a try-catch block around port-forward function in order to catch errors and dump information about them into the console. This helps when users are having issues with booting while not all services are running fine.
